### PR TITLE
feat: add topic_name, node_name_override and param_name_prefix as modifiers [SC-16779]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 *.pydevproject
 *~ 
 
+build
+log
+install

--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -156,10 +156,11 @@ class DiagnosticTaskVector:
     class DiagnosticTaskInternal:
         """Class used to represent a diagnostic task internally."""
 
-        def __init__(self, name, fn):
+        def __init__(self, name, fn, prefix_override=''):
             """Construct a DiagnosticTaskInternal."""
             self.name = name
             self.fn = fn
+            self.prefix_override = prefix_override
 
         def run(self, stat):
             """Run the task."""
@@ -181,20 +182,22 @@ class DiagnosticTaskVector:
         """
         pass
 
-    def add(self, *args):
+    def add(self, *args, prefix_override=''):
         """
         Add a task to the DiagnosticTaskVector.
 
         Usage:
         add(task): where task is a DiagnosticTask
         add(name, fn): add a DiagnosticTask embodied by a name and function
+        add(task, prefix_override='prefix'): add with custom prefix
+        add(name, fn, prefix_override='prefix'): add with custom prefix
         """
         if len(args) == 1:
             task = DiagnosticTaskVector.DiagnosticTaskInternal(
-                args[0].getName(), args[0].run)
+                args[0].getName(), args[0].run, prefix_override)
         elif len(args) == 2:
             task = DiagnosticTaskVector.DiagnosticTaskInternal(
-                args[0], args[1])
+                args[0], args[1], prefix_override)
 
         with self.lock:
             self.tasks.append(task)
@@ -232,22 +235,34 @@ class Updater(DiagnosticTaskVector):
     interval.
     """
 
-    def __init__(self, node, period=1.0):
+    def __init__(
+        self,
+        node,
+        period=1.0,
+        topic_name='/diagnostics',
+        node_name_override='',
+        param_name_prefix='diagnostic_updater'
+    ):
         """Construct an updater class."""
         DiagnosticTaskVector.__init__(self)
         self.node = node
+        self.topic_name = topic_name
         self.publisher = self.node.create_publisher(
-            DiagnosticArray, '/diagnostics', 1)
-        self.period_parameter = 'diagnostic_updater.period'
-        self.__period = self.node.declare_parameter(
-            self.period_parameter, period).value
+            DiagnosticArray, topic_name, 1)
+        self.period_parameter = param_name_prefix + '.period'
+        if self.node.has_parameter(self.period_parameter):
+            self.__period = self.node.get_parameter(
+                self.period_parameter).value
+        else:
+            self.__period = self.node.declare_parameter(
+                self.period_parameter, period).value
         self.timer = self.node.create_timer(self.__period, self.update)
 
         self.verbose = False
         self.hwid = ''
         self.warn_nohwid_done = False
 
-        self.use_fqn_parameter = 'diagnostic_updater.use_fqn'
+        self.use_fqn_parameter = param_name_prefix + '.use_fqn'
         if self.node.has_parameter(self.use_fqn_parameter):
             self.__use_fqn = self.node.get_parameter(
                 self.use_fqn_parameter).value
@@ -259,6 +274,20 @@ class Updater(DiagnosticTaskVector):
             self.node_name = '/'.join([self.node.get_namespace(), self.node.get_name()])
         else:
             self.node_name = self.node.get_name()
+
+        # If a node_name_override is provided, use it instead of the actual node name
+        if node_name_override:
+            self.node_name = node_name_override
+
+    def _get_effective_prefix(self, task_prefix):
+        """Get the effective prefix for a task."""
+        if task_prefix:
+            return task_prefix
+        return self.node_name
+
+    def setNodeName(self, node_name):
+        """Set the node name used as prefix in diagnostic names."""
+        self.node_name = node_name
 
     def update(self):
         """
@@ -281,6 +310,10 @@ class Updater(DiagnosticTaskVector):
                 status.hardware_id = self.hwid
 
                 status = task.run(status)
+
+                # Apply prefix (per-task override or global node name)
+                prefix = self._get_effective_prefix(task.prefix_override)
+                status.name = prefix + ': ' + status.name
 
                 status_vec.append(status)
 
@@ -334,6 +367,11 @@ class Updater(DiagnosticTaskVector):
             status = DiagnosticStatusWrapper()
             status.name = task.name
             status.summary(lvl, msg)
+
+            # Apply prefix (per-task override or global node name)
+            prefix = self._get_effective_prefix(task.prefix_override)
+            status.name = prefix + ': ' + status.name
+
             status_vec.append(status)
 
         self.publish(status_vec)
@@ -361,11 +399,11 @@ class Updater(DiagnosticTaskVector):
         if not type(msg) is list:
             msg = [msg]
 
+        # Prefix is now applied earlier in update(), broadcast(), and addedTaskCallback()
         now = self.node.get_clock().now()
         da = DiagnosticArray()
         da.header.stamp = now.to_msg()  # Add timestamp for ROS 0.10
         for stat in msg:
-            stat.name = self.node_name + ': ' + stat.name
             db = DiagnosticStatus()
             db.name = stat.name
             db.message = stat.message
@@ -380,4 +418,9 @@ class Updater(DiagnosticTaskVector):
         stat = DiagnosticStatusWrapper()
         stat.name = task.name
         stat.summary(DiagnosticStatus.OK, 'Node starting up')
+
+        # Apply prefix (per-task override or global node name)
+        prefix = self._get_effective_prefix(task.prefix_override)
+        stat.name = prefix + ': ' + stat.name
+
         self.publish(stat)

--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -218,7 +218,12 @@ protected:
   {
 public:
     DiagnosticTaskInternal(const std::string name, TaskFunction f)
-    : name_(name), fn_(f) {}
+    : name_(name), fn_(f), prefix_override_("") {}
+
+    DiagnosticTaskInternal(
+      const std::string name, TaskFunction f,
+      const std::string prefix_override)
+    : name_(name), fn_(f), prefix_override_(prefix_override) {}
 
     void run(diagnostic_updater::DiagnosticStatusWrapper & stat) const
     {
@@ -228,9 +233,12 @@ public:
 
     const std::string & getName() const {return name_;}
 
+    const std::string & getPrefixOverride() const {return prefix_override_;}
+
 private:
     std::string name_;
     TaskFunction fn_;
+    std::string prefix_override_;
   };
 
   std::mutex lock_;
@@ -292,6 +300,57 @@ public:
     void (T::* f)(diagnostic_updater::DiagnosticStatusWrapper &))
   {
     DiagnosticTaskInternal int_task(name, std::bind(f, c, std::placeholders::_1));
+    addInternal(int_task);
+  }
+
+  /**
+   * \brief Add a DiagnosticTask embodied by a name and function to the
+   * DiagnosticTaskVector with a prefix override
+   *
+   * \param name Name to autofill in the DiagnosticStatusWrapper for this task.
+   *
+   * \param f Function to call to fill out the DiagnosticStatusWrapper.
+   *
+   * \param prefix_override Prefix to use instead of node name for this task.
+   */
+  void add(const std::string & name, TaskFunction f, const std::string & prefix_override)
+  {
+    DiagnosticTaskInternal int_task(name, f, prefix_override);
+    addInternal(int_task);
+  }
+
+  /**
+   * \brief Add a DiagnosticTask to the DiagnosticTaskVector with a prefix override
+   *
+   * \param task The DiagnosticTask to be added.
+   *
+   * \param prefix_override Prefix to use instead of node name for this task.
+   */
+  void add(DiagnosticTask & task, const std::string & prefix_override)
+  {
+    TaskFunction f = std::bind(&DiagnosticTask::run, &task, std::placeholders::_1);
+    add(task.getName(), f, prefix_override);
+  }
+
+  /**
+   * \brief Add a DiagnosticTask embodied by a name and method to the
+   * DiagnosticTaskVector with a prefix override
+   *
+   * \param name Name to autofill in the DiagnosticStatusWrapper for this task.
+   *
+   * \param c Class instance the method is being called on.
+   *
+   * \param f Method to call to fill out the DiagnosticStatusWrapper.
+   *
+   * \param prefix_override Prefix to use instead of node name for this task.
+   */
+  template<class T>
+  void add(
+    const std::string name, T * c,
+    void (T::* f)(diagnostic_updater::DiagnosticStatusWrapper &),
+    const std::string & prefix_override)
+  {
+    DiagnosticTaskInternal int_task(name, std::bind(f, c, std::placeholders::_1), prefix_override);
     addInternal(int_task);
   }
 
@@ -363,11 +422,19 @@ public:
    *
    * \param node Node pointer to set up diagnostics
    * \param period Value in seconds to set the update period
-   * \note The given period value not being used if the `diagnostic_updater.period`
+   * \param topic_name Topic name for publishing diagnostics (default: "/diagnostics")
+   * \param node_name_override Prefix to replace node name in diagnostic names (default: "")
+   * \param param_name_prefix Prefix for parameter names (default: "diagnostic_updater")
+   * \note The given period value not being used if the `<param_name_prefix>.period`
    * ros2 parameter was set previously.
    */
   template<class NodeT>
-  explicit Updater(NodeT node, double period = 1.0)
+  explicit Updater(
+    NodeT node,
+    double period = 1.0,
+    const std::string & topic_name = "/diagnostics",
+    const std::string & node_name_override = "",
+    const std::string & param_name_prefix = "diagnostic_updater")
   : Updater(
       node->get_node_base_interface(),
       node->get_node_clock_interface(),
@@ -375,7 +442,10 @@ public:
       node->get_node_parameters_interface(),
       node->get_node_timers_interface(),
       node->get_node_topics_interface(),
-      period)
+      period,
+      topic_name,
+      node_name_override,
+      param_name_prefix)
   {}
 
   Updater(
@@ -385,7 +455,10 @@ public:
     std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
     std::shared_ptr<rclcpp::node_interfaces::NodeTimersInterface> timers_interface,
     std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface> topics_interface,
-    double period = 1.0);
+    double period = 1.0,
+    const std::string & topic_name = "/diagnostics",
+    const std::string & node_name_override = "",
+    const std::string & param_name_prefix = "diagnostic_updater");
 
   /**
    * \brief Returns the interval between updates.
@@ -407,6 +480,11 @@ public:
   void setPeriod(double period)
   {
     setPeriod(rclcpp::Duration::from_seconds(period));
+  }
+
+  void setNodeName(std::string node_name)
+  {
+    node_name_ = node_name;
   }
 
   /**
@@ -480,7 +558,10 @@ private:
 
   std::string hwid_;
   std::string node_name_;
+  std::string topic_name_;
   bool warn_nohwid_done_;
+
+  std::string getEffectivePrefix(const std::string & task_prefix) const;
 };
 }   // namespace diagnostic_updater
 

--- a/diagnostic_updater/src/diagnostic_updater.cpp
+++ b/diagnostic_updater/src/diagnostic_updater.cpp
@@ -44,19 +44,24 @@ Updater::Updater(
   std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface> logging_interface,
   std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
   std::shared_ptr<rclcpp::node_interfaces::NodeTimersInterface> timers_interface,
-  std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface> topics_interface, double period)
+  std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface> topics_interface,
+  double period,
+  const std::string & topic_name,
+  const std::string & node_name_override,
+  const std::string & param_name_prefix)
 : verbose_(false),
   base_interface_(base_interface),
   timers_interface_(timers_interface),
   clock_(clock_interface->get_clock()),
   period_(rclcpp::Duration::from_seconds(period)),
   publisher_(rclcpp::create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
-      topics_interface, "/diagnostics", 1)),
+      topics_interface, topic_name, 1)),
   logger_(logging_interface->get_logger()),
   node_name_(base_interface->get_name()),
+  topic_name_(topic_name),
   warn_nohwid_done_(false)
 {
-  constexpr const char * period_param_name = "diagnostic_updater.period";
+  std::string period_param_name = param_name_prefix + ".period";
   rclcpp::ParameterValue period_param;
   if (parameters_interface->has_parameter(period_param_name)) {
     period_param = parameters_interface->get_parameter(period_param_name).get_parameter_value();
@@ -69,7 +74,7 @@ Updater::Updater(
 
   reset_timer();
 
-  constexpr const char * use_fqn_param_name = "diagnostic_updater.use_fqn";
+  std::string use_fqn_param_name = param_name_prefix + ".use_fqn";
   rclcpp::ParameterValue use_fqn_param;
   if (parameters_interface->has_parameter(use_fqn_param_name)) {
     use_fqn_param = parameters_interface->get_parameter(use_fqn_param_name).get_parameter_value();
@@ -79,6 +84,11 @@ Updater::Updater(
   }
   node_name_ = use_fqn_param.get<bool>() ? base_interface->get_fully_qualified_name() :
     base_interface->get_name();
+
+  // If a node_name_override is provided, use it instead of the actual node name
+  if (!node_name_override.empty()) {
+    node_name_ = node_name_override;
+  }
 }
 
 void Updater::broadcast(unsigned char lvl, const std::string msg)
@@ -93,6 +103,10 @@ void Updater::broadcast(unsigned char lvl, const std::string msg)
 
     status.name = iter->getName();
     status.summary(lvl, msg);
+
+    // Apply prefix (per-task override or global node name)
+    std::string prefix = getEffectivePrefix(iter->getPrefixOverride());
+    status.name = prefix + std::string(": ") + status.name;
 
     status_vec.push_back(status);
   }
@@ -141,6 +155,10 @@ void Updater::update()
 
       iter->run(status);
 
+      // Apply prefix (per-task override or global node name)
+      std::string prefix = getEffectivePrefix(iter->getPrefixOverride());
+      status.name = prefix + std::string(": ") + status.name;
+
       status_vec.push_back(status);
 
       if (status.level) {
@@ -177,11 +195,7 @@ void Updater::publish(diagnostic_msgs::msg::DiagnosticStatus & stat)
 
 void Updater::publish(std::vector<diagnostic_msgs::msg::DiagnosticStatus> & status_vec)
 {
-  for (std::vector<diagnostic_msgs::msg::DiagnosticStatus>::iterator iter = status_vec.begin();
-    iter != status_vec.end(); iter++)
-  {
-    iter->name = node_name_ + std::string(": ") + iter->name;
-  }
+  // Prefix is now applied earlier in update(), broadcast(), and addedTaskCallback()
   diagnostic_msgs::msg::DiagnosticArray msg;
   msg.status = status_vec;
   msg.header.stamp = clock_->now();
@@ -193,6 +207,19 @@ void Updater::addedTaskCallback(DiagnosticTaskInternal & task)
   DiagnosticStatusWrapper stat;
   stat.name = task.getName();
   stat.summary(0, "Node starting up");
+
+  // Apply prefix (per-task override or global node name)
+  std::string prefix = getEffectivePrefix(task.getPrefixOverride());
+  stat.name = prefix + std::string(": ") + stat.name;
+
   publish(stat);
+}
+
+std::string Updater::getEffectivePrefix(const std::string & task_prefix) const
+{
+  if (!task_prefix.empty()) {
+    return task_prefix;
+  }
+  return node_name_;
 }
 }  // namespace diagnostic_updater


### PR DESCRIPTION
- A combination of `topic_name` and `param_name_prefix` allows for multiple updaters in the same node
- node_name_override allows for more control over the naming in the diagnostic tasks

It's not the cleanest change, but aiming to reduce as many line changes as possible.